### PR TITLE
If dsn is set and driver is not present in dancer config file we get and error in Database.pm

### DIFF
--- a/lib/Dancer/Plugin/Database.pm
+++ b/lib/Dancer/Plugin/Database.pm
@@ -133,7 +133,7 @@ sub _get_connection {
     # so, unless they've set the auto_utf8 plugin setting to a false value.
     my $app_charset = Dancer::Config::setting('charset');
     my $auto_utf8 = exists $settings->{auto_utf8} ?  $settings->{auto_utf8} : 1;
-    if (lc $app_charset eq 'utf-8' && $auto_utf8) {
+    if (lc $app_charset eq 'utf-8' && $auto_utf8 && exists($settings->{driver}) ) {
         
         # The option to pass to the DBI->connect call depends on the driver:
         my %param_for_driver = (


### PR DESCRIPTION
Hi David,

I was using Dancer::Plugin::Database today with the Sybase driver and I set the dsn in the config file to what I wanted it to be.  I then removed the driver, database, and host settings as the doco says but ran into trouble with Database.pm reading an uninitialized hash value around line 144.  

This pull request fixes that issue, although you understand your code better than me and may find a better spot for it.

Cheers

Matt.
