### PR TITLE
Don't warn that we're adding UTF-8 support if we've already set it

### DIFF
--- a/lib/Dancer/Plugin/Database.pm
+++ b/lib/Dancer/Plugin/Database.pm
@@ -144,7 +144,10 @@ sub _get_connection {
             mysql  => 'mysql_enable_utf8',
             Pg     => 'pg_enable_utf8',
         );
-        if (my $param = $param_for_driver{$driver}) {
+
+        my $param = $param_for_driver{$driver};
+
+        if ($param && !$settings->{dbi_params}{$param}) {
             Dancer::Logger::debug(
                 "Adding $param to DBI connection params to enable UTF-8 support"
             );


### PR DESCRIPTION
Don't warn that we're adding UTF-8 support if we've already set it ourselves

It's just annoying to see the warning on every request - even if you've manually specified mysql_enable_utf8 to be true.
