### PR TITLE
Fetch specific columns using quick_select instead of entire row

### DIFF
--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -12,7 +12,7 @@ if ($@) {
     plan skip_all => 'DBD::SQLite required to run these tests';
 }
 
-plan tests => 23;
+plan tests => 26;
 
 my $dsn = "dbi:SQLite:dbname=:memory:";
 
@@ -53,6 +53,15 @@ response_content_like [ GET => '/quick_select/2/name' ], qr/bigpresh/,
 
 response_content_like [ GET => '/quick_lookup/bigpresh' ], qr/2/,
   'content looks good for /quick_lookup/bigpresh';
+
+response_content_like   [ GET => '/complex_where/42' ], qr/Bob/,
+    "Complex where clause succeeded";
+
+response_content_like   [ GET => '/complex_not/42' ], qr/sukria/,
+    "Complex not where clause succeeded";
+
+response_content_like   [ GET => '/set_op/2' ], qr/bigpresh/,
+    "set operation where clause succeeded";
 
 response_content_like  [ GET => '/quick_select_many' ], 
     qr/\b bigpresh,sukria \b/x,

--- a/t/lib/TestApp.pm
+++ b/t/lib/TestApp.pm
@@ -78,6 +78,24 @@ get '/quick_lookup/:name' => sub {
     return $id;
 };
 
+get '/complex_where/:id' => sub {
+    my $row = database->quick_select('users', { id => { 'gt' => '4' } });
+    return $row ? join(',', values %$row) 
+        : "No matching user"; 
+};
+
+get '/complex_not/:id' => sub {
+    my $row = database->quick_select('users', { category => { 'is' => undef, 'not' => 1 } });
+    return $row ? join(',', values %$row) 
+        : "No matching user"; 
+};
+
+get '/set_op/:id' => sub {
+    my $row = database->quick_select('users', { id => [ params->{id} ] });
+    return $row ? join(',', values %$row) 
+        : "No matching user"; 
+};
+
 get '/quick_select_many' => sub {
         my @users = database->quick_select('users', {  category => 'admin' });
         return join ',', sort map { $_->{name} } @users;


### PR DESCRIPTION
It was useful to me to fetch only specific columns using quick_select so I added the ability to specify an arrayref of column names to the end of the method.   I also added some syntactic sugar called quick_lookup which returns a single scalar value (not an array/hashref of a row) which is handy for converting a username to a userid or something. 

Thanks for this module. It's been really useful for my lil side project. Hope you like these changes. 

By the way, I've added some flexibility to WHERE clauses by inspecting the 1st character of the value.  

For example a first character of 

'%" means "WHERE key LIKE %value",

'>' means WHERE key > value, 

'<' means WHERE key < value

'!' means WHERE key IS NOT value

I have retained all of the meanings of {} where clauses and undef values to signify NULL.   I also added the ability to use an arrayref as a WHERE value to signify a set operator as in

{ foo => ['bar', 'baz'] } which would mean

WHERE foo IN ('bar', 'baz')

but I haven't written the test cases for those extensions yet, so I haven't sent you a pull request yet, but if you want a sneak preview, they're in my fork of your lib. I will try to finish the test cases in the next couple days and will send a pull request when they pass.

Mark
