### PR TITLE
Bugfix: Make ORDER clauses work when using WHERE clauses (missing space)...

### DIFF
--- a/lib/Dancer/Plugin/Database/Handle.pm
+++ b/lib/Dancer/Plugin/Database/Handle.pm
@@ -287,7 +287,7 @@ sub _quick_query {
 
     # Add an ORDER BY clause, if we want to:
     if (exists $opts->{order_by}) {
-        $sql .= $self->_build_order_by_clause($opts->{order_by});
+        $sql .= ' ' . $self->_build_order_by_clause($opts->{order_by});
     }
 
 


### PR DESCRIPTION
...

Example:

```
database->quick_select('nutzer', { pin => undef }, { order_by => 'handle' });
```

…would result in a MySQL error complaining about NULLORDER (due to missing space between the NULL of the WHERE clause and the ORDER keyword).
