### PR TITLE
Save a reference to the new handle when reconnecting

### DIFF
--- a/Shared/lib/Dancer/Plugin/Database/Core.pm
+++ b/Shared/lib/Dancer/Plugin/Database/Core.pm
@@ -97,7 +97,7 @@ sub database {
                 if ($handle->{dbh}) {
                     eval { $handle->{dbh}->disconnect }
                 }
-                return (_get_connection($conn_details, $logger, $hook_exec), $settings);
+                return ($handle->{dbh} = _get_connection($conn_details, $logger, $hook_exec), $settings);
             }
         }
     } else {


### PR DESCRIPTION
After a database disconnect, the current version of the code reconnects just fine, but doesn't seem to actually save the reference, so the next call will just find a handle that looks just as inactive as before, and attempt reconnection again.

This is not only wasteful in terms of reconnection attempts, it actually introduces bugs when the software around it depends on the session being stable between two calls.  (which was my case)

The proposed patch fixes that in a way that's good enough for me (TM).  I have no idea how to reliably test for this.
