### PR TITLE
Scalarrefs for verbatim values (for SQL function calls etc)

### DIFF
--- a/Shared/lib/Dancer/Plugin/Database/Core/Handle.pm
+++ b/Shared/lib/Dancer/Plugin/Database/Core/Handle.pm
@@ -313,7 +313,7 @@ sub _generate_sql {
     my @bind_params;
 
     my $sql = {
-        SELECT => "SELECT $which_cols FROM $table_name ",
+        SELECT => "SELECT $which_cols FROM $table_name",
         INSERT => "INSERT INTO $table_name ",
         UPDATE => "UPDATE $table_name SET ",
         DELETE => "DELETE FROM $table_name ",
@@ -334,7 +334,7 @@ sub _generate_sql {
 
     if ($type eq 'UPDATE' || $type eq 'DELETE' || $type eq 'SELECT' || $type eq 'COUNT')
     {
-        if (!ref $where) {
+        if ($where && !ref $where) {
             $sql .= " WHERE " . $where;
         } elsif ( ref $where eq 'HASH' ) {
             my @stmts;
@@ -365,7 +365,7 @@ sub _generate_sql {
                 }
             }
             $sql .= " WHERE " . join " AND ", @stmts if keys %$where;
-        } else {
+        } elsif (ref $where) {
             carp "Can't handle ref " . ref $where . " for where";
             return;
         }
@@ -404,7 +404,6 @@ sub _generate_sql {
             die "Invalid OFFSET param $opts->{offset} !";
         }
     }
-
     return ($sql, @bind_params);
 }
 

--- a/Shared/lib/Dancer/Plugin/Database/Core/Handle.pm
+++ b/Shared/lib/Dancer/Plugin/Database/Core/Handle.pm
@@ -328,7 +328,7 @@ sub _generate_sql {
                 } values %$data
             )
             . ")";
-        push @bind_params, values %$data;
+        push @bind_params, grep { ref $_ ne 'SCALAR' } values %$data;
     }
     if ($type eq 'UPDATE') {
         $sql .= join ',', map { $self->_quote_identifier($_) .'=?' } keys %$data;

--- a/Shared/lib/Dancer/Plugin/Database/Core/Handle.pm
+++ b/Shared/lib/Dancer/Plugin/Database/Core/Handle.pm
@@ -345,8 +345,11 @@ sub _generate_sql {
         push @bind_params, grep { ref $_ ne 'SCALAR' } values %$data;
     }
     if ($type eq 'UPDATE') {
-        $sql .= join ',', map { $self->_quote_identifier($_) .'=?' } keys %$data;
-        push @bind_params, values %$data;
+        $sql .= join ',', map {
+            $self->_quote_identifier($_) .'=' 
+            . (ref $data->{$_} eq 'SCALAR' ? ${$data->{$_}} : "?")
+        } keys %$data;
+        push @bind_params, grep { ref $_ ne 'SCALAR' } values %$data;
     }
 
     if ($type eq 'UPDATE' || $type eq 'DELETE' || $type eq 'SELECT' || $type eq 'COUNT')

--- a/Shared/lib/Dancer/Plugin/Database/Core/Handle.pm
+++ b/Shared/lib/Dancer/Plugin/Database/Core/Handle.pm
@@ -323,7 +323,10 @@ sub _generate_sql {
         $sql .= "("
             . join(',', map { $self->_quote_identifier($_) } keys %$data)
             . ") VALUES ("
-            . join(',', map { "?" } values %$data)
+            . join(',', map { 
+                    ref $_ eq 'SCALAR' ? $$_ : "?" 
+                } values %$data
+            )
             . ")";
         push @bind_params, values %$data;
     }

--- a/Shared/lib/Dancer/Plugin/Database/Core/Handle.pm
+++ b/Shared/lib/Dancer/Plugin/Database/Core/Handle.pm
@@ -351,15 +351,15 @@ sub _quick_query {
         $sql .= " LIMIT 1";
     }
     
-	if (exists $opts->{offset} and defined $opts->{offset}) {
-        my $offset = $opts->{offset};
-        $offset =~ s/\s+//g;
-		if ($offset =~ /^\d+$/) {
-			$sql .= " OFFSET $offset";
-		} else {
-            die "Invalid OFFSET param $opts->{offset} !";
-		}
-	}
+    if (exists $opts->{offset} and defined $opts->{offset}) {
+    my $offset = $opts->{offset};
+    $offset =~ s/\s+//g;
+            if ($offset =~ /^\d+$/) {
+                    $sql .= " OFFSET $offset";
+            } else {
+        die "Invalid OFFSET param $opts->{offset} !";
+            }
+    }
 
     # Dancer::Plugin::Database will have looked at the log_queries setting and
     # stashed it away for us to see:

--- a/Shared/lib/Dancer/Plugin/Database/Core/Handle.pm
+++ b/Shared/lib/Dancer/Plugin/Database/Core/Handle.pm
@@ -48,6 +48,13 @@ database handle, with the following added convenience methods:
 Given a table name and a hashref of data (where keys are column names, and the
 values are, well, the values), insert a row in the table.
 
+If you need any of the values to be interpolated straight into the SQL, for
+instance if you need to use a function call like C<NOW()> or similar, then you
+can provide them as a scalarref:
+
+  database->quick_insert('mytable', { foo => 'Bar', timestamp => \'NOW()' });
+
+Of course, if you do that, you must be careful to avoid SQL injection attacks!
 =cut
 
 sub quick_insert {
@@ -61,6 +68,13 @@ sub quick_insert {
 
 Given a table name, a hashref describing a where clause and a hashref of
 changes, update a row.
+
+As per quick_insert, if you need any of the values to be interpolated straight
+in the SQL, for e.g. to use a function call, provide a scalarref:
+
+  database->quick_update('mytable', { id => 42 }, { counter => \'counter + 1' });
+
+Of course, if you do that, you must be careful to avoid SQL injection attacks!
 
 =cut
 

--- a/Shared/t/01-handle.t
+++ b/Shared/t/01-handle.t
@@ -41,17 +41,20 @@ my @sql_tests = (
         name       => "Simple SELECT, no WHERE",
         params     => [ 'SELECT', 'tablename', {} ],
         expect_sql => qq{SELECT * FROM "tablename"},
+        expect_bind_params => [],
     },
     {
         name       => "SELECT with named columns, no WHERE",
         params     => ['SELECT', 'tablename', { columns => [qw(one two) ] } ],
         expect_sql => qq{SELECT "one","two" FROM "tablename"},
+        expect_bind_params => [],
     },
 
     {
         name       => "SELECT with literal string WHERE",
         params     => ['SELECT', 'tablename', undef, 'BEER IS GOOD' ],
         expect_sql => qq{SELECT * FROM "tablename" WHERE BEER IS GOOD},
+        expect_bind_params => [],
     },
 
     {

--- a/Shared/t/01-handle.t
+++ b/Shared/t/01-handle.t
@@ -74,7 +74,7 @@ my @sql_tests = (
     {
         name       => "INSERT with scalarrefs untouched",
         params     => ['INSERT', 'tablename', { one => \'NOW()', two => '2' } ],
-        expect_sql => qq{INSERT INTO "tablename" ("one","two") VALUES (NOW(), ?)},
+        expect_sql => qq{INSERT INTO "tablename" ("one","two") VALUES (NOW(),?)},
     },
 );
 

--- a/Shared/t/01-handle.t
+++ b/Shared/t/01-handle.t
@@ -50,4 +50,39 @@ for my $identifier (keys %quoting_tests) {
     );
 }
 
+# SQL-generation tests.  Each test is an arrayref consisting of an arrayref of
+# params to pass to _generate_sql(), the SQL to expect, and the bind columns to
+# expect.
+my @sql_tests = (
+    {
+        name       => "Simple SELECT, no WHERE",
+        params     => [ 'SELECT', 'tablename', {} ],
+        expect_sql => qq{SELECT * FROM "tablename"},
+    },
+    {
+        name       => "SELECT with named columns, no WHERE",
+        params     => ['SELECT', 'tablename', { columns => [qw(one two) ] } ],
+        expect_sql => qq{SELECT "one","two" FROM "tablename"},
+    },
+
+    {
+        name       => "SELECT with literal string WHERE",
+        params     => ['SELECT', 'tablename', undef, 'BEER IS GOOD' ],
+        expect_sql => qq{SELECT * FROM "tablename" WHERE BEER IS GOOD},
+    },
+
+    {
+        name       => "INSERT with scalarrefs untouched",
+        params     => ['INSERT', 'tablename', { one => \'NOW()', two => '2' } ],
+        expect_sql => qq{INSERT INTO "tablename" ("one","two") VALUES (NOW(), ?)},
+    },
+);
+
+
+for my $test (@sql_tests) {
+    my ($sql, @bind_params) = $handle->_generate_sql(@{ $test->{params} });
+    is($sql, $test->{expect_sql}, "Got expected SQL for $test->{name}");
+}
+
+
 

--- a/Shared/t/01-handle.t
+++ b/Shared/t/01-handle.t
@@ -30,25 +30,7 @@ my %quoting_tests = (
     'foo.bar' => '"foo"."bar"',
 );
 
-plan tests => scalar @order_by_tests + scalar keys %quoting_tests;
 
-my $i;
-for my $test (@order_by_tests) {
-    $i++;
-    my $res = $handle->_build_order_by_clause($test->[0]);
-    is($res, $test->[1],
-        sprintf "Order by test %d/%d : %s",
-            $i, scalar @order_by_tests, $res
-    );
-}
-
-for my $identifier (keys %quoting_tests) {
-    is(
-        $handle->_quote_identifier($identifier),
-        $quoting_tests{$identifier},
-        "Quoted '$identifier' as '$quoting_tests{$identifier}'"
-    );
-}
 
 # SQL-generation tests.  Each test is an arrayref consisting of an arrayref of
 # params to pass to _generate_sql(), the SQL to expect, and the bind columns to
@@ -78,6 +60,26 @@ my @sql_tests = (
     },
 );
 
+plan tests 
+    => scalar @order_by_tests + scalar keys(%quoting_tests) + scalar @sql_tests;
+
+my $i;
+for my $test (@order_by_tests) {
+    $i++;
+    my $res = $handle->_build_order_by_clause($test->[0]);
+    is($res, $test->[1],
+        sprintf "Order by test %d/%d : %s",
+            $i, scalar @order_by_tests, $res
+    );
+}
+
+for my $identifier (keys %quoting_tests) {
+    is(
+        $handle->_quote_identifier($identifier),
+        $quoting_tests{$identifier},
+        "Quoted '$identifier' as '$quoting_tests{$identifier}'"
+    );
+}
 
 for my $test (@sql_tests) {
     my ($sql, @bind_params) = $handle->_generate_sql(@{ $test->{params} });

--- a/Shared/t/01-handle.t
+++ b/Shared/t/01-handle.t
@@ -55,9 +55,20 @@ my @sql_tests = (
     },
 
     {
+        name       => "SELECT with simple WHERE values",
+        params     => [
+            'SELECT', 'tablename', undef, { foo => 'One', bar => 'Two' }
+        ],
+        # Expected order differs - columns alphabetical
+        expect_sql => qq{SELECT * FROM "tablename" WHERE "bar"=? AND "foo"=?},
+        expect_bind_params => ['Two','One'],
+    },
+
+    {
         name       => "INSERT with scalarrefs untouched",
         params     => ['INSERT', 'tablename', { one => \'NOW()', two => '2' } ],
         expect_sql => qq{INSERT INTO "tablename" ("one","two") VALUES (NOW(),?)},
+        expect_bind_params => [ 2 ],
     },
     {
         name       => "UPDATE with scalarrefs untouched",


### PR DESCRIPTION
This feature allows you to pass a scalarref when you want a value untouched by the normal parameterisation, so you could say e.g.:

```perl
$handle->quick_update($table, { id => 42 }, { foo => 'One', timestamp => \'NOW()' });
```
(Obviously, if you do that, it's included in the SQL as you provide it, so only you can prevent wildfires^WSQL injection attacks - be careful.)

This also includes refactoring out of the SQL & bind values generation into its own method, `_generate_sql()` for testability, and a variety of tests exercising it (testing both previous expected functionality, and the new functionality).

This was prompted by a question from @b100s on Freenode/#perl earlier.