### PR TITLE
Fix data handling and SQL building in update queries

### DIFF
--- a/Shared/lib/Dancer/Plugin/Database/Core/Handle.pm
+++ b/Shared/lib/Dancer/Plugin/Database/Core/Handle.pm
@@ -353,12 +353,13 @@ sub _generate_sql {
     }
 
     if ($type eq 'UPDATE') {
-        my (@keys, @values);
-        $sql .= join ',', map {
-            $self->_quote_identifier($_) .'=' 
-            . (ref $data->{$_} eq 'SCALAR' ? ${$data->{$_}} : "?")
-        } sort keys %$data;
-        push @bind_params, grep { ref $_ ne 'SCALAR' } values %$data;
+        my @sql;
+        for (sort keys %$data) {
+          push @sql, $self->_quote_identifier($_) . '=' .
+            (ref $data->{$_} eq 'SCALAR' ? ${$data->{$_}} : "?");
+          push @bind_params, $data->{$_} if (ref $data->{$_} ne 'SCALAR');
+        }
+        $sql .= join ',', @sql;
     }
 
     if ($type eq 'UPDATE' || $type eq 'DELETE' || $type eq 'SELECT' || $type eq 'COUNT')


### PR DESCRIPTION
The current version of the code may lead no malformed SQL, because of the sort while building the SQL, the @bind_params list may end up with the values in a different order than the binding names in the SQL. This is a possible fix, it seems to work correctly, feel free to address the problem in a different way.