### PR TITLE
Tuning Dancer2 plugin with minimum perl version

### DIFF
--- a/Dancer2/Makefile.PL
+++ b/Dancer2/Makefile.PL
@@ -1,15 +1,14 @@
 use strict;
 use warnings;
-use ExtUtils::MakeMaker;
+use ExtUtils::MakeMaker 6.48;
 
 WriteMakefile(
     NAME                => 'Dancer2::Plugin::Database',
     AUTHOR              => q{David Precious <davidp@preshweb.co.uk>},
     VERSION_FROM        => 'lib/Dancer2/Plugin/Database.pm',
     ABSTRACT_FROM       => 'lib/Dancer2/Plugin/Database.pm',
-    ($ExtUtils::MakeMaker::VERSION >= 6.3002
-      ? ('LICENSE'=> 'perl')
-      : ()),
+    MIN_PERL_VERSION    => '5.010',
+    LICENSE             => 'perl',
     PL_FILES            => {},
     PREREQ_PM => {
         'Dancer2'                        => '0.151000',

--- a/Dancer2/lib/Dancer2/Plugin/Database.pm
+++ b/Dancer2/lib/Dancer2/Plugin/Database.pm
@@ -2,6 +2,8 @@ package Dancer2::Plugin::Database;
 
 use strict;
 
+use 5.010;
+
 use Dancer::Plugin::Database::Core;
 use Dancer::Plugin::Database::Core::Handle;
 


### PR DESCRIPTION
Latest Dancer2 fails tests for perl versions < 5.10.0:
http://matrix.cpantesters.org/?dist=Dancer2+0.163000

So it could be better to have minimum version defined.