### PR TITLE
use $dsl->config instead of plugin_settings for plugin2

### DIFF
--- a/Dancer2/lib/Dancer2/Plugin/Database.pm
+++ b/Dancer2/lib/Dancer2/Plugin/Database.pm
@@ -28,7 +28,7 @@ my $settings = {};
 sub _load_settings {
     my $dsl = shift;
     # ugly plugin1/2 switch - to be removed one day
-    if ( $dsl->can('with_plugin') ) {
+    if ( $dsl->app->can('with_plugin') ) {
         # plugin2
         # We need this for plugins which use this plugins
         $settings = $dsl->config;

--- a/Dancer2/lib/Dancer2/Plugin/Database.pm
+++ b/Dancer2/lib/Dancer2/Plugin/Database.pm
@@ -27,7 +27,16 @@ my $settings = {};
 
 sub _load_settings {
     my $dsl = shift;
-    $settings = plugin_setting();
+    # ugly plugin1/2 switch - to be removed one day
+    if ( $dsl->can('with_plugin') ) {
+        # plugin2
+        # We need this for plugins which use this plugins
+        $settings = $dsl->config;
+    }
+    else {
+        # plugin1
+        $settings = plugin_setting();
+    }
     $settings->{charset} ||= $dsl->setting('charset') || 'utf-8';
 }
 


### PR DESCRIPTION
Any plugins which use this plugin will not work when plugin1's
plugin_config keyword is used and so if we smell plugin2 we get config
via $dsl->config instead. This is needed by
Dancer2::Plugin::Auth::Extensible::Provider::Database.

Thanks to yanick for the pointer.