### PR TITLE
With multiple connections, emphasize need to provide name of connection.

### DIFF
--- a/Dancer2/lib/Dancer2/Plugin/Database.pm
+++ b/Dancer2/lib/Dancer2/Plugin/Database.pm
@@ -244,8 +244,8 @@ your config under C<connections> as shown below:
                     host: "localhost"
                     ....
 
-Then, you can call the C<database> keyword with the name of the database
-connection you want, for example:
+Then, you can -- indeed, I<must> -- call the C<database> keyword with the name
+of the database connection you want, for example:
 
     my $foo_dbh = database('foo');
     my $bar_dbh = database('bar');


### PR DESCRIPTION
This slight documentation change reflects discussion in GH issue 85.

Cf.: https://github.com/bigpresh/Dancer-Plugin-Database/issues/85