### PR TITLE
Shared...Handle.pm - prettify bind parameters' debug output

### DIFF
--- a/Shared/lib/Dancer/Plugin/Database/Core/Handle.pm
+++ b/Shared/lib/Dancer/Plugin/Database/Core/Handle.pm
@@ -283,8 +283,8 @@ sub _quick_query {
             "Executing $type query $sql with params " . join ',', 
             map {
                 defined $_ ? 
-                $_ =~ /^[[:ascii:]]+$/ ? 
-                    length $_ > 50 ? substr($_, 0, 47) . '...' : $_
+                $_ =~ /^[[:ascii:]]*$/ ?
+                    "'" . (length $_ > 50 ? substr($_, 0, 47) . '...' : $_) . "'"
                 : "[non-ASCII data not logged]" : 'undef'
             } @bind_params
         );


### PR DESCRIPTION
Firstly, the empty string contains no non-ASCII, so can be logged as normal.
Secondly, enclose the values in quotes to make delineation easier when SETs
are involved, as they use internal comma separation.

Signed-off-by: Phil Carmody <pc+github@asdf.org>