### PR TITLE
Added hook for before database connections

### DIFF
--- a/Dancer1/Changes
+++ b/Dancer1/Changes
@@ -1,5 +1,9 @@
 Revision history for Dancer-Plugin-Database
 
+2.14    2018-11-20
+        [ ENHANCEMENTS ]
+        - added pre database connection hook
+
 2.13    2016-08-13
         [ BUG FIXES ]
         - Require 0.16 of core library, as 0.15 had a bug in :(

--- a/Dancer1/lib/Dancer/Plugin/Database.pm
+++ b/Dancer1/lib/Dancer/Plugin/Database.pm
@@ -16,7 +16,7 @@ Dancer::Plugin::Database - easy database connections for Dancer applications
 
 =cut
 
-our $VERSION = '2.13';
+our $VERSION = '2.14';
 
 my $settings = undef;
 
@@ -42,7 +42,9 @@ register database => sub {
 register_hook(qw(database_connected
                  database_connection_lost
                  database_connection_failed
-                 database_error));
+                 database_error
+                 database_connection_new
+                 ));
 
 register_plugin;
 
@@ -313,6 +315,12 @@ to connect (as obtained from the config file).
 
 Called when a database error is raised by C<DBI>.  Receives two parameters: the
 error message being returned by DBI, and the database handle in question.
+
+=item C<database_connection_new>
+
+Called when a new database connection is about to be created.  Receives a hashref of
+connection settings as a parameter, containing the settings the plugin will be using
+to connect (as obtained from the config file).
 
 =back
 

--- a/Dancer2/Changes
+++ b/Dancer2/Changes
@@ -1,5 +1,9 @@
 Revision history for Dancer2-Plugin-Database
 
+2.17    2018-11-20
+        [ ENHANCEMENTS ]
+        - added pre database connection hook
+
 2.17    2016-08-13
 
         [ BUG FIXES ]

--- a/Dancer2/lib/Dancer2/Plugin/Database.pm
+++ b/Dancer2/lib/Dancer2/Plugin/Database.pm
@@ -16,12 +16,13 @@ Dancer2::Plugin::Database - easy database connections for Dancer2 applications
 
 =cut
 
-our $VERSION = '2.17';
+our $VERSION = '2.18';
 
 register_hook qw(database_connected
                  database_connection_lost
                  database_connection_failed
-                 database_error);
+                 database_error
+                 database_connection_new);
 
 
 my $settings = {};
@@ -342,6 +343,12 @@ to connect (as obtained from the config file).
 
 Called when a database error is raised by C<DBI>.  Receives two parameters: the
 error message being returned by DBI, and the database handle in question.
+
+=item C<database_connection_new>
+
+Called when a new database connection is about to be created.  Receives a hashref of
+connection settings as a parameter, containing the settings the plugin will be using
+to connect (as obtained from the config file).
 
 =back
 

--- a/Shared/Changes
+++ b/Shared/Changes
@@ -1,5 +1,9 @@
 Revision history for Dancer-Plugin-Database-Core
 
+0.21    2018-11-20
+        [ ENHANCEMENTS ]
+        - added hook for pre database connection
+
 0.20    2016-09-01
         [ ENHANCEMENTS ]
         - Support "ILIKE" for Postgres users (Mario Duhanic)

--- a/Shared/lib/Dancer/Plugin/Database/Core.pm
+++ b/Shared/lib/Dancer/Plugin/Database/Core.pm
@@ -10,7 +10,7 @@ Dancer::Plugin::Database::Core - Shared core for D1 and D2 Database plugins
 
 =cut
 
-our $VERSION = '0.20';
+our $VERSION = '0.21';
 
 my %handles;
 # Hashref used as key for default handle, so we don't have a magic value that
@@ -202,6 +202,7 @@ sub _set_defaults {
 sub _get_connection {
     my ($settings, $logger, $hook_exec) = @_;
 
+    $hook_exec->('database_connection_new', $settings);
     if (!$settings->{dsn} && !$settings->{driver}) {
         die "Can't get a database connection without settings supplied!\n"
             . "Please check you've supplied settings in config as per the "


### PR DESCRIPTION
Happy Holidays!

This pull is intended to resolve rt.cpan.org ticket: 127745.
I didn't look through all the readme files originally or I would have just done a git pull request originally.

Also after testing in my local cpan repo I found versons x.xxc didn't progress the version properly in the cpan client, so I have adjusted the version number in the fork.

Sorry for the extra leg work, if you started updating the code all ready.

Original ticket notes here:

Hello,

My name is Michael Shipper Cpan user is "akalinux". Happy holidays and thank you for the wonderful Perl code you have contributed over the years!

I have a use case ( mostly dealing with oracle ) where I need to have my process run code prior to the connection.  My apologies for listing this as a bug, I didn't know of a way to provide a patch or enhancement through rt.cpan.org.

I would like to propose the following patchs to this module and another patch to the "Dancer2::Plugin::Database" module.

I have attached a patched version of both cpan dists to this rt.cpan.org bug.  

diff Dancer-Plugin-Database-Core-0.20/lib/Dancer/Plugin/Database/Core.pm Dancer-Plugin-Database-Core-0.20c/lib/Dancer/Plugin/Database/Core.pm
13c13
< our $VERSION = '0.20';
---
Hide quoted text
> our $VERSION = '0.20c';
204a205
Hide quoted text
>     $hook_exec->('database_connection_new', $settings);



diff Dancer2-Plugin-Database-2.17/lib/Dancer2/Plugin/Database.pm Dancer2-Plugin-Database-2.17c/lib/Dancer2/Plugin/Database.pm 
19c19
< our $VERSION = '2.17';
---
Hide quoted text
> our $VERSION = '2.17c';
24c24,25
<                  database_error);
---
Hide quoted text
>                  database_error 
>                  database_connection_new);
338a340,345
Hide quoted text
> 
> =item C<database_connection_new>
> 
> Called when a new database connection is about to be created.  Receives a hashref of
> connection settings as a parameter, containing the settings the plugin will be using
> to connect (as obtained from the config file).
