### PR TITLE
Documentation - improve mysql configuration example

### DIFF
--- a/Dancer2/lib/Dancer2/Plugin/Database.pm
+++ b/Dancer2/lib/Dancer2/Plugin/Database.pm
@@ -147,7 +147,11 @@ should be specified as, for example:
             dbi_params:
                 RaiseError: 1
                 AutoCommit: 1
-            on_connect_do: ["SET NAMES 'utf8'", "SET CHARACTER SET 'utf8'" ]
+                ShowErrorStatement: 1 # DBI append relevant statement text to error messages
+                mysql_auto_reconnect: 1
+                mysql_enable_utf8: 1 # DBI::mysql support up to 3 byte UTF-8 encoding in older MySQL and DBD::mysql versions
+                mysql_enable_utf8mb4: 1 # from DBI::mysql 4.032 support 4 byte UTF-8 encoding in MySQL version 5.5 or later
+            on_connect_do: ["SET NAMES 'utf8'", "SET CHARACTER SET 'utf8'", "SET SQL_MODE='TRADITIONAL'" ]
             log_queries: 1
             handle_class: 'My::Super::Sexy::Database::Handle'
 


### PR DESCRIPTION
- add ShowErrorStatement to append relevant statement text to error messages
- add mysql_enable_utf8 and mysql_enable_utf8mb4 flags to add UTF-8 encoding
  support for up to 3 (older) or 4 bit (newer) DBD::mysql and MySQL server
- add SET_SQL_MODE='TRADITIONAL' to turn on strict mode in MySQL for errors